### PR TITLE
fix: comment adding of communication link to dynamic link contacts

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -355,7 +355,7 @@ class Communication(Document):
 			self.add_link("Contact", contact_name)
 
 			# link contact's dynamic links to communication
-			# add_contact_links_to_communication(self, contact_name) # commented out as the dynamic links: Customer/Supplier should not be linked to communication only on Contact timeline
+			# add_contact_links_to_communication(self, contact_name) # Commented out as the dynamic links: Customer/Supplier should not be linked to communication only on Contact timeline
 
 	def deduplicate_timeline_links(self):
 		if self.timeline_links:

--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -355,7 +355,7 @@ class Communication(Document):
 			self.add_link("Contact", contact_name)
 
 			# link contact's dynamic links to communication
-			add_contact_links_to_communication(self, contact_name)
+			# add_contact_links_to_communication(self, contact_name) # commented out as the dynamic links: Customer/Supplier should not be linked to communication only on Contact timeline
 
 	def deduplicate_timeline_links(self):
 		if self.timeline_links:
@@ -592,3 +592,4 @@ def set_avg_response_time(parent, communication):
 			if response_times:
 				avg_response_time = sum(response_times) / len(response_times)
 				parent.db_set("avg_response_time", avg_response_time)
+


### PR DESCRIPTION
**Asana:** https://app.asana.com/0/1203283251131831/1207895033520677/f

**Issue:** 
NEXT Master contacts are used to link email to particular Customer/Supplier. With this, if it is linked to multiple customers, any notification made from user will populate to the timeline of the linked customer or supplier which it should not because it is not relevant. 

**Fix:** 
Except the NEXT Master contact in adding timeline links whenever a notification to the customer/supplier is made. 